### PR TITLE
Extract graphite configuration interface

### DIFF
--- a/src/OhioBox.Metrics.Tests/OhioBox.Metrics.Tests.csproj
+++ b/src/OhioBox.Metrics.Tests/OhioBox.Metrics.Tests.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="NUnit" Version="2.6.4" />
-		<PackageReference Include="OhioBox.Time" Version="2.0.1" />
+		<PackageReference Include="OhioBox.Time" Version="2.1.6" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="System" />

--- a/src/OhioBox.Metrics/OhioBox.Metrics.csproj
+++ b/src/OhioBox.Metrics/OhioBox.Metrics.csproj
@@ -25,6 +25,6 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
 	</ItemGroup>
 	<ItemGroup>
-	  <PackageReference Include="OhioBox.Time" Version="2.1.3" />
+	  <PackageReference Include="OhioBox.Time" Version="2.1.6" />
 	</ItemGroup>
 </Project>

--- a/src/OhioBox.Metrics/Reporters/Graphite/GraphiteMetricsReporterFactory.cs
+++ b/src/OhioBox.Metrics/Reporters/Graphite/GraphiteMetricsReporterFactory.cs
@@ -4,10 +4,10 @@ namespace OhioBox.Metrics.Reporters.Graphite
 {
 	public class GraphiteMetricsReporterFactory : IMetricsReporterFactory
 	{
-		private readonly GraphiteConfiguration _configuration;
+		private readonly IGraphiteConfiguration _configuration;
 		private readonly IGraphiteSwitch _graphiteSwitch;
 
-		public GraphiteMetricsReporterFactory(GraphiteConfiguration configuration, IGraphiteSwitch graphiteSwitch = null)
+		public GraphiteMetricsReporterFactory(IGraphiteConfiguration configuration, IGraphiteSwitch graphiteSwitch = null)
 		{
 			_configuration = configuration;
 			_graphiteSwitch = graphiteSwitch;

--- a/src/OhioBox.Metrics/Reporters/Graphite/GraphiteReporter.cs
+++ b/src/OhioBox.Metrics/Reporters/Graphite/GraphiteReporter.cs
@@ -13,7 +13,7 @@ namespace OhioBox.Metrics.Reporters.Graphite
 		private readonly UdpClient _udpClient;
 		private readonly string _prefix;
 
-		public GraphiteReporter(GraphiteConfiguration configuration, IGraphiteSwitch graphiteSwitch)
+		public GraphiteReporter(IGraphiteConfiguration configuration, IGraphiteSwitch graphiteSwitch)
 		{
 			if (configuration.IpAddress == null)
 				return;

--- a/src/OhioBox.Metrics/Reporters/Graphite/IGraphiteConfiguration.cs
+++ b/src/OhioBox.Metrics/Reporters/Graphite/IGraphiteConfiguration.cs
@@ -1,6 +1,13 @@
 ﻿namespace OhioBox.Metrics.Reporters.Graphite
 {
-	public class GraphiteConfiguration
+	public interface IGraphiteConfiguration
+	{
+		string IpAddress { get; }
+		bool ReportMachineName { get; }
+		string Prefix { get; }
+	}
+
+	public class GraphiteConfiguration : IGraphiteConfiguration
 	{
 		public string IpAddress { get; }
 		public bool ReportMachineName { get; }


### PR DESCRIPTION
Add interface to graphite configuration to allow using custom configurations instead of the concrete class to the reporter